### PR TITLE
fix(didInitState): Add BuildContext to function call

### DIFF
--- a/lib/app/base_screen.dart
+++ b/lib/app/base_screen.dart
@@ -51,7 +51,7 @@ abstract class BaseScreen extends StatefulWidget
   @override
   Future<bool> willPopScope() async => true;
 
-  void didInitState() {}
+  void didInitState(BuildContext context) {}
 }
 
 class _BaseScreenState extends State<BaseScreen> with AfterInitMixin<BaseScreen> {
@@ -63,7 +63,7 @@ class _BaseScreenState extends State<BaseScreen> with AfterInitMixin<BaseScreen>
 
   @override
   void didInitState() {
-    widget.didInitState();
+    widget.didInitState(context);
   }
 
   @override


### PR DESCRIPTION
It makes much more sense to have the context available in this functions, so I'm adding it to the `didInitState()` function signature, turning it into `didInitState(BuildContext context)`.